### PR TITLE
Bugs/environment endpoint

### DIFF
--- a/src/funcs.ts
+++ b/src/funcs.ts
@@ -124,7 +124,7 @@ export function activateGetPresignedUrl(
 }
 
 let ade_server = '';
-var valuesUrl = new URL(PageConfig.getBaseUrl() + 'maapsec/environment');
+var valuesUrl = new URL(PageConfig.getBaseUrl() + 'jupyter-server-extension/getConfig');
 
 request('get', valuesUrl.href).then((res: RequestResult) => {
   if (res.ok) {


### PR DESCRIPTION
Changed endpoint `maapsec/environment` to `jupyter-server-extension/getConfig` which is now correct. This fixes the get presigned url bug for the most part

There is also another bug getting the keycloak error that only happens sometimes, and I am still working on that but it might not be available by this upcoming release

Also, I know @marjo-luc you said maapsec is now outdated. There is a line in uwm that still uses it, profileId. Definition [here](https://github.com/MAAP-Project/user-workspace-management-jupyter-extension/blob/b18d7706c94ab35e94d15d98a46ae2344a17cbbf/src/funcs.ts#L13) and usage [here](https://github.com/MAAP-Project/user-workspace-management-jupyter-extension/blob/b18d7706c94ab35e94d15d98a46ae2344a17cbbf/src/funcs.ts#L150). Does this need to be changed? And if so, how?