### PR TITLE
Bug/set pgt token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maap-user-workspace-management-jupyter-extension",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Manage user resources.",
   "keywords": [
     "jupyter",

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -78,7 +78,6 @@ export class InjectSSH {
             }
 
             if (profile != undefined) {
-              console.log("graceal1 profile was not undefined so making call to injectPGT")
               let getUrlInjectPGT = new URL(PageConfig.getBaseUrl() + "jupyter-server-extension/uwm/injectPGT");
               getUrlInjectPGT.searchParams.append("proxyGrantingTicket", profile['proxyGrantingTicket']);
 
@@ -88,6 +87,8 @@ export class InjectSSH {
               };
               xhrInjectPGT.open("GET", getUrlInjectPGT.href, true);
               xhrInjectPGT.send(null);
+            } else {
+              Notification.warning("Profile not defined so PGT token not set. Some services may be unavailable.");
             }
         }
         else {

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -68,14 +68,26 @@ export class InjectSSH {
             } else {
               let getUrlInjectPublicKey = new URL(PageConfig.getBaseUrl() + "jupyter-server-extension/uwm/injectPublicKey");
               getUrlInjectPublicKey.searchParams.append("key", key);
-              getUrlInjectPublicKey.searchParams.append("proxyGrantingTicket", profile['proxyGrantingTicket']);
-
-              let xhrInject = new XMLHttpRequest();
-              xhrInject.onload = function() {
-                  console.log("Checked for/injected user's public key and PGT");
+              
+              let xhrInjectPublicKey = new XMLHttpRequest();
+              xhrInjectPublicKey.onload = function() {
+                  console.log("Checked for/injected user's public key");
               };
-              xhrInject.open("GET", getUrlInjectPublicKey.href, true);
-              xhrInject.send(null);
+              xhrInjectPublicKey.open("GET", getUrlInjectPublicKey.href, true);
+              xhrInjectPublicKey.send(null);
+            }
+
+            if (profile != undefined) {
+              console.log("graceal1 profile was not undefined so making call to injectPGT")
+              let getUrlInjectPGT = new URL(PageConfig.getBaseUrl() + "jupyter-server-extension/uwm/injectPGT");
+              getUrlInjectPGT.searchParams.append("proxyGrantingTicket", profile['proxyGrantingTicket']);
+
+              let xhrInjectPGT = new XMLHttpRequest();
+              xhrInjectPGT.onload = function() {
+                  console.log("Checked for/injected user's PGT");
+              };
+              xhrInjectPGT.open("GET", getUrlInjectPGT.href, true);
+              xhrInjectPGT.send(null);
             }
         }
         else {


### PR DESCRIPTION
Separated `injectPublicKey` and `injectPGT` into 2 different calls to avoid errors in `injectPublicKey` not injecting the PGT token into the environment 

Relevant PR to jupyter server extension: https://github.com/MAAP-Project/jupyter-server-extension/pull/20

Can test with: `mas.dit.maap-project.org/root/maap-workspaces/jupyterlab/python:set-pgt-token`